### PR TITLE
chore: Bump peer deps for React

### DIFF
--- a/packages/react-navi/package.json
+++ b/packages/react-navi/package.json
@@ -30,7 +30,7 @@
   ],
   "peerDependencies": {
     "navi": "^0.14.0",
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17"
   },
   "dependencies": {
     "@types/history": "^4.6.2"

--- a/packages/react-navi/package.json
+++ b/packages/react-navi/package.json
@@ -30,7 +30,7 @@
   ],
   "peerDependencies": {
     "navi": "^0.14.0",
-    "react": "^16.8.0 || ^17"
+    "react": "^16.8.0 || ^17 || ^18"
   },
   "dependencies": {
     "@types/history": "^4.6.2"


### PR DESCRIPTION
## Things to note
- This solves the main issue by bumping `react-navi`'s peer deps to the right version of React